### PR TITLE
Exchange refactoring

### DIFF
--- a/apps/event_bus/lib/event_bus.ex
+++ b/apps/event_bus/lib/event_bus.ex
@@ -23,7 +23,6 @@ defmodule EventBus do
     end
   end
 
-
   def cast_event(:order_cancelled, %EventBus.OrderCancelled{} = payload),
     do: dispatch_event(:order_cancelled, payload)
 


### PR DESCRIPTION
**event_bus.ex:**
- removed extra line to prevent warning from credo.

**matching_engine.ex:**
- corrected spread spec.
- handle_call for limit order and market order are now compliant with the order book's minimum and maximum price.

**order_book_test.exs:**

- added test for some edge cases and to test the increment_or_decrement function.


**order_book.ex:**
- added and refactored some specs.
- the price_time_match doesn't leave empty queues in the order book structure. (update_queue)
- in price_time_match when fetched order is matched as empty it is updated the max_bid or ask_min depending on the order and the order is queued.
- the calculation of min_ask or max_bid is compliant with the minimum and maximum price of the order book.
- price bound check added to increment_ask_min and decrement_bid_max.